### PR TITLE
Fix issue where pagination was returning after one Page

### DIFF
--- a/aws-apigateway-exporter/main.go
+++ b/aws-apigateway-exporter/main.go
@@ -111,7 +111,7 @@ func (e *Exporter) collectCertificateMetrics(up *int, ch chan<- prometheus.Metri
 					}
 				}
 			}
-			return lastPage
+			return !lastPage
 		})
 }
 
@@ -164,7 +164,7 @@ func (e *Exporter) collectUsageMetrics(up *int, ch chan<- prometheus.Metric) err
 				}
 			}
 
-			return lastPage
+			return !lastPage
 		})
 }
 


### PR DESCRIPTION
We encountered an issue where pagination was not working correctly, as the fn callbacks that are passed to the ApiGateway *WithPages functions were returning the incorrect boolean value